### PR TITLE
[fix][client] Empty repeat group pages

### DIFF
--- a/packages/infoportal-client/src/features/Database/Database.tsx
+++ b/packages/infoportal-client/src/features/Database/Database.tsx
@@ -30,7 +30,7 @@ import {useReactRouterDefaultRoute} from '@/core/useReactRouterDefaultRoute'
 import {useKoboSchemaContext} from '@/features/KoboSchema/KoboSchemaContext'
 import {appConfig} from '@/conf/AppConfig'
 import {useKoboAnswersContext} from '@/core/context/KoboAnswersContext'
-import {DatabaseKoboRepeatRoute} from '@/features/Database/RepeatGroup/DatabaseKoboRepeatGroup'
+import {DatabaseKoboRepeatRoute} from '@/features/Database/RepeatGroup'
 
 export const databaseUrlParamsValidation = yup.object({
   formId: yup.string().required(),

--- a/packages/infoportal-client/src/features/Database/KoboTable/DatabaseKoboTableContent.tsx
+++ b/packages/infoportal-client/src/features/Database/KoboTable/DatabaseKoboTableContent.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from 'react'
 import {Alert, AlertProps, Icon, useTheme} from '@mui/material'
 import {Kobo} from 'kobo-sdk'
-import {useNavigate, useNavigation, useNavigationType} from 'react-router-dom'
+import {useNavigate} from 'react-router-dom'
 
 import {KoboFlattenRepeatedGroup, KoboIndex, Legal_individual_aid} from 'infoportal-common'
 
@@ -60,7 +60,6 @@ export const DatabaseKoboTableContent = ({
   const {m} = useI18n()
   const t = useTheme()
   const navigate = useNavigate()
-  const navigation = useNavigationType()
   const {session} = useSession()
   const ctx = useDatabaseKoboTableContext()
   const ctxSchema = useKoboSchemaContext()

--- a/packages/infoportal-client/src/features/Database/KoboTable/DatabaseKoboTableContent.tsx
+++ b/packages/infoportal-client/src/features/Database/KoboTable/DatabaseKoboTableContent.tsx
@@ -1,10 +1,9 @@
 import {useMemo, useState} from 'react'
 import {Alert, AlertProps, Icon, useTheme} from '@mui/material'
 import {Kobo} from 'kobo-sdk'
-import {useNavigate} from 'react-router-dom'
+import {useNavigate, useNavigation, useNavigationType} from 'react-router-dom'
 
-import {KoboFlattenRepeatedGroup, KoboIndex} from 'infoportal-common'
-import {Legal_individual_aid} from 'infoportal-common/kobo/generated/Legal_individual_aid'
+import {KoboFlattenRepeatedGroup, KoboIndex, Legal_individual_aid} from 'infoportal-common'
 
 import {appConfig} from '@/conf/AppConfig'
 import {useAppSettings} from '@/core/context/ConfigContext'
@@ -61,13 +60,13 @@ export const DatabaseKoboTableContent = ({
   const {m} = useI18n()
   const t = useTheme()
   const navigate = useNavigate()
+  const navigation = useNavigationType()
   const {session} = useSession()
   const ctx = useDatabaseKoboTableContext()
   const ctxSchema = useKoboSchemaContext()
   const ctxAnswers = useKoboAnswersContext()
   const ctxKoboUpdate = useKoboUpdateContext()
   const [selectedIds, setSelectedIds] = useState<Kobo.SubmissionId[]>([])
-
   const flatData: KoboMappedAnswer[] | undefined = useMemo(() => {
     if (ctx.groupDisplay.get.repeatAs !== 'rows' || ctx.groupDisplay.get.repeatGroupName === undefined) return ctx.data
     return KoboFlattenRepeatedGroup.run({
@@ -97,8 +96,9 @@ export const DatabaseKoboTableContent = ({
       formId: ctx.form.id,
       schema: ctx.schema,
       externalFilesIndex: ctx.externalFilesIndex,
-      onRepeatGroupClick: (_) =>
-        navigate(databaseIndex.siteMap.group.absolute(ctx.form.id, _.name, _.row.id, _.row._index)),
+      onRepeatGroupClick: ({name, row}) => {
+        navigate(databaseIndex.siteMap.group.relative(name, row.id, row._index))
+      },
       onEdit:
         selectedIds.length > 0
           ? (questionName) =>

--- a/packages/infoportal-client/src/features/Database/RepeatGroup/index.ts
+++ b/packages/infoportal-client/src/features/Database/RepeatGroup/index.ts
@@ -1,0 +1,1 @@
+export {DatabaseKoboRepeatRoute} from './DatabaseKoboRepeatGroup'

--- a/packages/infoportal-client/src/features/Database/RepeatGroup/types.ts
+++ b/packages/infoportal-client/src/features/Database/RepeatGroup/types.ts
@@ -1,0 +1,6 @@
+interface DatabaseKoboRepeatGroupProps {
+  formId?: string
+  backLink?: string
+}
+
+export type {DatabaseKoboRepeatGroupProps}

--- a/packages/infoportal-client/src/features/Legal/IndividualAid/Data/Data.tsx
+++ b/packages/infoportal-client/src/features/Legal/IndividualAid/Data/Data.tsx
@@ -65,7 +65,7 @@ const Data: FC = () => {
           setCasePeriod={setCasePeriod}
           caseClosurePeriod={caseClosurePeriod}
           setCaseClosurePeriod={setCaseClosurePeriod}
-          slotProps={{wrapperBox: {paddingInline: 2}}}
+          slotProps={{wrapperBox: {paddingInline: 1}}}
         />
         <DatabaseTable
           formId={KoboIndex.byName('legal_individual_aid').id}

--- a/packages/infoportal-client/src/features/Legal/Legal.tsx
+++ b/packages/infoportal-client/src/features/Legal/Legal.tsx
@@ -2,6 +2,7 @@ import {useEffect, type FC} from 'react'
 import {Navigate, Route, Routes} from 'react-router-dom'
 
 import {appFeaturesIndex} from '@/features/appFeatureId'
+import {DatabaseKoboRepeatRoute} from '@/features/Database/RepeatGroup'
 import {Layout} from '@/shared/Layout'
 import {AppHeader} from '@/shared/Layout/Header/AppHeader'
 
@@ -24,7 +25,18 @@ const Legal: FC = () => {
         <Route path={pages.individualLegalAid.slug}>
           <Route index element={<Navigate to={pages.individualLegalAid.dashboard.slug} replace />} />
           <Route path={pages.individualLegalAid.dashboard.slug} element={<IndividualAidDashboard />} />
-          <Route path={pages.individualLegalAid.data.slug} element={<IndividualAidData />} />
+          <Route path={pages.individualLegalAid.data.slug}>
+            <Route index element={<IndividualAidData />} />
+            <Route
+              path={pages.individualLegalAid.data.group.slug}
+              element={
+                <DatabaseKoboRepeatRoute
+                  formId="aJxhKpk5fw5SYjEkBopxvJ"
+                  backLink={`/${pages.individualLegalAid.data.path}`}
+                />
+              }
+            />
+          </Route>
         </Route>
       </Routes>
     </Layout>

--- a/packages/infoportal-client/src/features/Legal/Legal.tsx
+++ b/packages/infoportal-client/src/features/Legal/Legal.tsx
@@ -1,6 +1,8 @@
 import {useEffect, type FC} from 'react'
 import {Navigate, Route, Routes} from 'react-router-dom'
 
+import {KoboIndex} from 'infoportal-common'
+
 import {appFeaturesIndex} from '@/features/appFeatureId'
 import {DatabaseKoboRepeatRoute} from '@/features/Database/RepeatGroup'
 import {Layout} from '@/shared/Layout'
@@ -31,7 +33,7 @@ const Legal: FC = () => {
               path={pages.individualLegalAid.data.group.slug}
               element={
                 <DatabaseKoboRepeatRoute
-                  formId="aJxhKpk5fw5SYjEkBopxvJ"
+                  formId={KoboIndex.byName('legal_individual_aid').id}
                   backLink={`/${pages.individualLegalAid.data.path}`}
                 />
               }

--- a/packages/infoportal-client/src/features/Legal/config.ts
+++ b/packages/infoportal-client/src/features/Legal/config.ts
@@ -10,6 +10,10 @@ const pages = {
     data: {
       path: `${root}/data`,
       slug: 'data',
+      group: {
+        path: `${root}/data/group/:group`,
+        slug: `group/:group`,
+      },
     },
   },
 }


### PR DESCRIPTION
Make repeat group table more reusable:
• add an option to take formId and back link from component's props

Utilize repeat group table in Legal's Individual Aid page